### PR TITLE
Bump AngularJS dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Check out the demo page at http://indrimuska.github.io/angular-counter.
 
 ## Dependencies
 
-* [jQuery](https://jquery.com/) >= 1.7.1
+* [jQuery](https://jquery.com/) >= 1.8
 * [jQuery Easing](http://gsgd.co.uk/sandbox/jquery/easing/) by gsgd, CDN [here](http://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js)
-* [AngularJS](https://angularjs.org/)
+* [AngularJS](https://angularjs.org/) >= 1.6
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-counter",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "An AngularJS directive to animate number increment/decrement.",
   "main": "Gruntfile.js",
   "repository": {
@@ -22,7 +22,7 @@
   },
   "homepage": "http://indrimuska.github.io/angular-counter",
   "dependencies": {
-    "angular": "~1.4.3",
+    "angular": ">=1.6.0",
     "jquery": ">=1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
All our other libraries depend on AngularJS >= 1.6. This one is forcing two versions in the same package, the older of which has security advisories.